### PR TITLE
Install Packages from GitHub Package Registry, if indicated

### DIFF
--- a/.github/workflows/integrate-landingpages-frontend.yml
+++ b/.github/workflows/integrate-landingpages-frontend.yml
@@ -2,6 +2,16 @@ name: "Integrate"
 
 on:
   workflow_call:
+    secrets:
+      GH_PACKAGES_INSTALL_TOKEN:
+        required: false
+        description: 'GitHub Token used to install private NPM packages from GitHub Packages registry.'
+    inputs:
+      installsPrivatePackage:
+        description: 'Determine if private NPM packages from Github Packages registry should be installed.'
+        required: false
+        type: string
+        default: false
 
 jobs:
   frontend-build:
@@ -14,8 +24,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      # Install frontend dependencies the ususal way, if no private NPM packages
+      # from GitHub Packages registry should be installed
       - name: Install Frontend Dependencies
+        if: inputs.installsPrivatePackage == false
         uses: bahmutov/npm-install@v1
+
+      # Add GitHub Packages registry to NPM, if private packages should be installed.
+      - uses: actions/setup-node@v3
+        if: inputs.installsPrivatePackage == true
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+
+      # Install frontend dependencies including private NPM packages.
+      - name: Install Frontend Dependencies
+        if: inputs.installsPrivatePackage == true
+        uses: bahmutov/npm-install@v1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_INSTALL_TOKEN }}
 
       - name: Build Frontend Assets
         run: yarn prod

--- a/.github/workflows/integrate-landingpages-frontend.yml
+++ b/.github/workflows/integrate-landingpages-frontend.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   frontend-build:
-    if: github.actor == 'dependabot[bot]'
+    # if: github.actor == 'dependabot[bot]'
     name: Frontend Build
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/integrate-landingpages-frontend.yml
+++ b/.github/workflows/integrate-landingpages-frontend.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   frontend-build:
-    # if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     name: Frontend Build
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/integrate-landingpages-frontend.yml
+++ b/.github/workflows/integrate-landingpages-frontend.yml
@@ -27,19 +27,19 @@ jobs:
       # Install frontend dependencies the ususal way, if no private NPM packages
       # from GitHub Packages registry should be installed
       - name: Install Frontend Dependencies
-        if: inputs.installsPrivatePackage == false
+        if: inputs.installsPrivatePackage == 'false'
         uses: bahmutov/npm-install@v1
 
       # Add GitHub Packages registry to NPM, if private packages should be installed.
       - uses: actions/setup-node@v3
-        if: inputs.installsPrivatePackage == true
+        if: inputs.installsPrivatePackage == 'true'
         with:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
 
       # Install frontend dependencies including private NPM packages.
       - name: Install Frontend Dependencies
-        if: inputs.installsPrivatePackage == true
+        if: inputs.installsPrivatePackage == 'true'
         uses: bahmutov/npm-install@v1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_INSTALL_TOKEN }}


### PR DESCRIPTION
Add new secret and input to support installation of private NPM packages from GitHub Package registry.

Installation of private packages is therefore made opt-in, as we otherwise have to add the GH_PACKAGES_INSTALL_TOKEN secret to a lot of workflows, which don’t use private NPM packages.