### PR TITLE
Update php version to 8.2 as default

### DIFF
--- a/.github/workflows/integrate-landingpages-backend.yml
+++ b/.github/workflows/integrate-landingpages-backend.yml
@@ -11,7 +11,7 @@ on:
         description: 'Version of PHP to be used'
         required: false
         type: string
-        default: '8.0'
+        default: '8.2'
 jobs:
   build:
     name: Build

--- a/.github/workflows/on-demand-landingpage-build.yml
+++ b/.github/workflows/on-demand-landingpage-build.yml
@@ -12,7 +12,7 @@ on:
         description: 'Version of PHP to be used'
         required: false
         type: string
-        default: '8.1'
+        default: '8.2'
     secrets:
       COMPOSER_GITHUB_TOKEN:
         required: true


### PR DESCRIPTION
## Description

I'd like to have PHP 8.2 everywhere.

Or do we still need the default to 8.1 for a project?